### PR TITLE
chore(anthropic): version 3.0.12

### DIFF
--- a/.changeset/great-panthers-report.md
+++ b/.changeset/great-panthers-report.md
@@ -1,5 +1,0 @@
----
-'@zenning/anthropic': patch
----
-
-Add Claude 5 family (claude-sonnet-5, claude-opus-5, claude-fable-5, claude-mythos-5) and the 4.6-4.8 generation to getModelCapabilities (128K max output, structured outputs). Previously these fell through to the unknown-model default of 4,096 max_tokens, silently truncating large tool calls on any request that omitted maxOutputTokens. Unknown models relying on the default now emit a warning.

--- a/packages/anthropic/CHANGELOG.md
+++ b/packages/anthropic/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ai-sdk/anthropic
 
+## 3.0.12
+
+### Patch Changes
+
+- Add the Claude 5 family (claude-sonnet-5, claude-opus-5, claude-fable-5, claude-mythos-5) and the 4.6-4.8 generation to getModelCapabilities (128K max output). Previously these fell through to the unknown-model default of 4,096 max_tokens, silently truncating large tool calls on any request that omitted maxOutputTokens. Unknown models relying on the default now emit a warning. supportsStructuredOutput deliberately stays false for the new entries so default-mode generateObject callers keep the json-tool wire format. (3.0.10 and 3.0.11 were published from earlier out-of-band builds; this release supersedes them.)
+
 ## 3.0.9
 
 ### Patch Changes

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenning/anthropic",
-  "version": "3.0.9",
+  "version": "3.0.12",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for publishing the Claude 5 capability fix (#7). npm already carries 3.0.10/3.0.11 from earlier out-of-band publishes while the repo sat at 3.0.9, so this releases as **3.0.12**. Consumes the changeset.

The fork's Release workflow is gated `if: github.repository_owner == 'vercel'` and never runs here, so after merging, publish manually:

```bash
cd packages/anthropic && pnpm install && pnpm build && npm publish --access public
```

(needs `npm login` first — no npm auth on the dev machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ZenningAI/codesmith/ai/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788249248&installation_model_id=21469&pr_number=8&repository=ZenningAI%2Fai&return_to=https%3A%2F%2Fgithub.com%2FZenningAI%2Fai%2Fpull%2F8&signature=7c6fa6d55df865ad4358f3b2936e3b6069bc8e9b211f98a90c36335c17184099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->